### PR TITLE
Tidy up spec.files in gemspec

### DIFF
--- a/rubynew.gemspec
+++ b/rubynew.gemspec
@@ -13,23 +13,19 @@ Gem::Specification.new do |spec|
   spec.homepage      = "http://github.com/napcs/rubynew"
   spec.license       = "MIT"
 
-  spec.files         = [
-                        "bin/rubynew",
-                        "lib/rubynew.rb",
-                        "lib/rubynew/version.rb",
-                        "lib/rubynew/project.rb",
-                        "template/Rakefile",
-                        "template/lib/app/version.rb",
-                        "template/lib/app.rb",
-                        "template/test/app_test.rb",
-                        "test/rubynew_test.rb",
-                        "Rakefile",
-                        "Gemfile",
-                        "README.md",
-                        "rubynew.gemspec",
-                        "LICENSE.txt"
+  spec.files = [
+    "bin/rubynew"
+    "Rakefile",
+    "Gemfile",
+    "README.md",
+    "rubynew.gemspec",
+    "LICENSE.txt"
+  ]
 
-                        ]
+  spec.files += Dir["lib/**/*"]
+  spec.files += Dir["template/**/*"] 
+  spec.files += Dir["test/**/*"] 
+
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]


### PR DESCRIPTION
If you add new files to the repo, you will need to add them to the list in `.gemspec` too. You might forget to add some in the future, and so I've made it easier by just including everything from `lib`, `templates` and `test` by default.
